### PR TITLE
modified_config.hosts

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,5 +73,5 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
-  config.hosts << "6527b81035534b648cdfadd8cd365bc7.vfs.cloud9.ap-northeast-1.amazonaws.com"
+  config.hosts.clear
 end


### PR DESCRIPTION
アクセス権限がなかったので、config.hostsを見直しました。ファイルは一つだけ書き換えたので、朝になったらご確認をお願いします！
因みに、アクセスを開発者4人に限定するときの書き方は、
(略)
30(行数:例)　config.hosts<< 番号
31(行数:例)　config.hosts<< 番号
(略)　　　　らしいです。
カリキュラムで権限について指定があったら、僕が見落としてただけなので、このpullは承認しないでください。