### PR TITLE
Fix pub orders index

### DIFF
--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -57,8 +57,8 @@ class Public::OrdersController < ApplicationController
 
   def index
     @customer=current_customer
-    @order = Order.all.order(id: "DESC")
-    @orders = @order.page(params[:page])
+    @order = @customer.orders.all.order(id: "DESC")
+    @orders = @order.page(params[:page]).per(10)
   end
 
   def show

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -2,10 +2,10 @@
   <div class="row">
    <div class="col-sm-12 col-md-11 col-lg-8 px-5 px-sm-0 mx-auto my-3" >
     <h3 class="mb-3">会員一覧</h3>
-     <table class='table table-hover'>
+     <table class='table table-dark'>
       <thead>
         <tr class="table-active">
-        <th>会員ID</th>
+         <th>会員ID</th>
          <th>氏名</th>
          <th>メールアドレス</th>
          <th>ステータス</th>
@@ -23,7 +23,7 @@
            <% else %>
            <P class="text-success font-weight-bold">有効</P>
            <% end %>
-           </td>
+          </td>
         </tr>
         <% end %>
       </tbody>

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row mt-5 d-flex justify-content-between">
-    <div class="bg-light my-3 ml-4">
-      <h5>ショッピングカート</h5>
+    <div class="my-3 ml-4">
+      <h4>ショッピングカート</h4>
     </div>
     <div>
       <% unless @cart_items.empty? %>
@@ -12,7 +12,7 @@
 
   <div class="row">
     <table class="table table-bordered border-dark">
-      <thead class="table-secondary">
+      <thead class="table-dark">
         <tr>
           <th class="col-md-4">商品名</th>
           <th class="col-md-2">単価(税込)</th>
@@ -61,7 +61,7 @@
     <div class="col-md-4 mt-3 px-0">
       <table class="table table-bordered">
         <tr>
-          <th class="col-5 table-secondary">合計金額</th>
+          <th class="col-5 table-dark">合計金額</th>
           <td class="col-5">
             <%= number_with_delimiter @total_price %>
           </td>

--- a/app/views/public/customers/show.html.erb
+++ b/app/views/public/customers/show.html.erb
@@ -12,36 +12,36 @@
      <table class="table table-bordered">
         <tbody>
           <tr>
-            <th class="bg-light w-25 border-dark">氏名</th>
+            <th class="bg-dark w-25 border-dark text-light">氏名</th>
             <td class="border-dark">
               <%= @customer.full_name %>
             </td>
           </tr>
 
           <tr>
-            <th class="bg-light border-dark">フリガナ</th>
+            <th class="bg-dark border-dark text-light">フリガナ</th>
             <td class="border-dark">
               <%= @customer.full_name_kana %>
             </td>
           </tr>
 
           <tr>
-            <th class="bg-light border-dark">郵便番号</th>
+            <th class="bg-dark border-dark text-light">郵便番号</th>
             <td class="border-dark"><%= @customer.post_code %></td>
           </tr>
 
           <tr>
-            <th class="bg-light border-dark">住所</th>
+            <th class="bg-dark border-dark text-light">住所</th>
             <td class="border-dark"><%= @customer.address %></td>
           </tr>
 
           <tr>
-            <th class="bg-light border-dark">電話番号</th>
+            <th class="bg-dark border-dark text-light">電話番号</th>
             <td class="border-dark"><%= @customer.phone_number %></td>
           </tr>
 
           <tr>
-            <th class="bg-light border-dark">メールアドレス</th>
+            <th class="bg-dark border-dark text-light">メールアドレス</th>
             <td class="border-dark"><%= @customer.email %></td>
           </tr>
         </tbody>

--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <h2 class="px-3 my-3">注文履歴一覧</h2>
     <table class="table table-bordered my-4">
-      <thead class="table table-secondary">
+      <thead class="table table-dark">
         <tr>
           <th>注文日</th>
           <th>配送先</th>
@@ -15,14 +15,18 @@
       <tbody>
         <% @orders.each do |order| %>
           <tr>
-            <td><%= l order.created_at, format: :short %></td>
-            <td><%= order.address_display %></td>
+            <td><%= order.created_at.strftime('%Y/%m/%d') %></td>
+            <td>
+              〒<%= order.post_code %><br>
+              <%= order.address %><br>
+              <%= order.name %>
+            </td>
             <td>
               <% order.order_items.each do |order_item| %>
               <%= order_item.item.name %><br>
               <% end %>
             </td>
-            <td><%= order.pay_total %>円</td>
+            <td><%= order.pay_total.to_s(:delimited) %>円</td>
             <td><%= order.status_i18n %></td>
             <td><%= link_to "表示する",order_path(order.id),class:"btn btn-md btn-primary" %></td>
           </tr>


### PR DESCRIPTION
●注文履歴一覧（会員側）
注文日（年月日に変更）
配送先：郵便番号で改行、名前の表示
数字3桁区切り
自分以外の履歴を表示させない
テーブルの見出しカラーをダークに変更