### PR TITLE
Oga Fix orders show customer link

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -2,7 +2,7 @@ class Admin::CustomersController < ApplicationController
     before_action :authenticate_admin!
 
   def index
-    @customer = Customer.all.order(id: "DESC")
+    @customer = Customer.all
     @customers = @customer.page(params[:page])
   end
 

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,8 +1,9 @@
 class Admin::ItemsController < ApplicationController
+  before_action :authenticate_admin!
+
   def index
-    @item = Item.all.order(id: "DESC")
+    @item = Item.all
     @items = @item.page(params[:page]) #kaminari(ページネーション)導入のため
-    # @items = Item.all
   end
 
   def show

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,15 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-  # itemsテーブルのストロングパラメーター
-  # private
-  # def item_params
-  #   params.require(:item).permit(:name, :description, :price, :status, :item_image)
-  # end
+  def after_sign_out_path_for(resource_or_scope)
+    if resource_or_scope == :customer
+        root_path
+    elsif resource_or_scope == :admin
+        new_admin_session_path
+    else
+        root_path
+    end
+  end
 
   private
 

--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -1,6 +1,6 @@
 class Public::ItemsController < ApplicationController
   def index
-    @items = Item.all.page(params[:page]).per(8)
+    @items = Item.where(status:true).page(params[:page]).per(8)
     @genres = Genre.all
   end
 
@@ -9,5 +9,5 @@ class Public::ItemsController < ApplicationController
     @cart_item = CartItem.new
     @genres = Genre.all
   end
-   
+
 end

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -31,8 +31,10 @@ class Public::SessionsController < Devise::SessionsController
       # 【処理内容3】一致しているが退会済みの場合：サインアップにリダイレクト
       flash[:notice] = "退会済みです。再度ご登録をしてご利用ください。"
       redirect_to new_customer_registration_path
+    elsif (@customer.valid_password?(params[:customer][:password]) == false) && (@customer.id_deleted == true)
+      flash[:notice] = "パスワードが違います。"
     else
-      flash[:alert] = "必要項目を入力してください。"
+      flash[:notice] = "必要項目を入力してください。"
     end
   end
 

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -2,9 +2,9 @@
   <div class="row">
    <div class="col-sm-12 col-md-11 col-lg-8 px-5 px-sm-0 mx-auto my-3" >
     <h3 class="mb-3">会員一覧</h3>
-     <table class='table table-dark'>
-      <thead>
-        <tr class="table-active">
+     <table class='table'>
+      <thead class="table-dark">
+        <tr>
          <th>会員ID</th>
          <th>氏名</th>
          <th>メールアドレス</th>

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -10,21 +10,21 @@
       <h4><span class="bg-light">ジャンル一覧・追加<span></h4>
       <div class="mt-4">
         <!--ジャンル名登録フォーム-->
-        
+
           <%= form_with model: @genre, url: admin_genres_path, local:true do |f| %>
           <ul class="d-flex">
             <li class="mr-5"><%= f.label :name, 'ジャンル名' %></li>
             <li class="mr-5"><%= f.text_field :name %></li>
             <li><%= f.submit '新規登録', class:"btn btn-sm btn-success pt-1 pb-1 px-4" %></li>
-          </ul>  
+          </ul>
           <% end %>
-      
+
       </div>
 
       <!--既に登録されているジャンルのリスト-->
       <div class="col-8 mt-4">
         <table class="table">
-          <thead class="table-secondary">
+          <thead class="table-dark">
             <tr>
               <th>ジャンル</th>
               <th></th>

--- a/app/views/admin/homes/top.html.erb
+++ b/app/views/admin/homes/top.html.erb
@@ -16,9 +16,9 @@
   <div class="col-sm-12 col-md-11 col-lg-8  mx-auto">
    <br>
 　 <h3>注文履歴一覧</h3>
-   <table class='table table-hover'>
-    <thead>
-      <tr class="table-active">
+   <table class='table'>
+    <thead class="table table-dark">
+      <tr>
         <th>購入日時</th>
         <th>購入者</th>
         <th>注文個数</th>

--- a/app/views/admin/items/_index.html.erb
+++ b/app/views/admin/items/_index.html.erb
@@ -1,5 +1,5 @@
 <table class='table'>
-  <thead class="table table-secondary">
+  <thead class="table table-dark">
     <tr>
       <th>商品ID</th>
       <th>商品名</th>
@@ -17,7 +17,7 @@
       <!--商品名-->
       <td class="align-middle"><p class="m-0"><%= link_to item.name, admin_item_path(item.id) %></p></td>
       <!--税抜価格-->
-      <td class="align-middle"><p class="m-0"><%= item.price %></p></td>
+      <td class="align-middle"><p class="m-0"><%= item.price.to_s(:delimited) %></p></td>
       <!--ジャンル-->
       <td class="align-middle"><p class="m-0"><%= item.genre.name %></p></td>
       <!--販売ステータス-->

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,13 +1,13 @@
 <div class='container px-5 px-sm-0'>
   <div class="row my-4">
-    <div class="m-3 bg-light">
+    <div class="m-3">
       <h5>注文履歴詳細</h5>
     </div>
   </div>
 
   <div class="row py-2">
     <div class="col-2"><strong>購入者</strong></div>
-    <div class="col-5"><u><%= link_to @order.customer.full_name, admin_customer_path(@order), class: "text-dark"%></u></div>
+    <div class="col-5"><u><%= link_to @order.customer.full_name, admin_customer_path(@order.customer), class: "text-dark"%></u></div>
   </div>
 
   <div class="row py-2">

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -18,7 +18,7 @@
             <%= image_tag item.item_image, size: "200x160" %>
             <% end %><br>
             <%= item.name %><br>
-            ¥<%= item.price %>
+            ¥<%= item.price.to_s(:delimited) %>
           </div>
         <% end %>
       </div>

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -3,7 +3,7 @@
   <div class="row">
     <div class="col-8">
       <table class="table table-bordered">
-        <thead class="table-active">
+        <thead class="table-dark">
           <tr>
             <th>商品名</th>
             <th>単価（税込み）</th>
@@ -30,15 +30,15 @@
     <div class="col-3  offset-1">
       <table class="table table-bordered table-sm">
         <tr>
-          <th class="table-active">送料</th>
+          <th class="table-dark">送料</th>
           <td>800</td>
         </tr>
         <tr>
-          <th class="table-active">商品合計</th>
+          <th class="table-dark">商品合計</th>
           <td><%= @total_price.to_s(:delimited) %></td>
         </tr>
         <tr>
-          <th class="table-active">請求金額</th>
+          <th class="table-dark">請求金額</th>
           <td><%= (@total_price + 800).to_s(:delimited) %></td>
         </tr>
       </table>

--- a/app/views/public/sessions/new.html.erb
+++ b/app/views/public/sessions/new.html.erb
@@ -1,18 +1,18 @@
 <div class="container-lg mx-auto mt-5" style="width: 600px;">
  <h2><span class="bg-light">ログイン<span></h2>
-  <% flash[:alert] %>
+ <% flash[:alert] %>
 
  <h4 class="mt-4"><span class="bg-light">会員の方はこちらからログイン</span></h4>
  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
    <div class="field d-flex justify-content-between mt-4" style="width: 400px;">
      <%= f.label :"メールアドレス" %>
      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-    </div> 
+    </div>
    <div class="field d-flex justify-content-between mt-4" style="width: 400px;">
     <%= f.label :"パスワード" %>
     <%= f.password_field :password, autofocus: true, autocomplete: "current-password" %>
    </div>
-  
+
    <% if devise_mapping.rememberable? %>
    <div class="field mt-4">
     <%= f.check_box :remember_me %>
@@ -22,9 +22,9 @@
    <div class="actions d-flex justify-content-center mt-4">
     <%= f.submit "ログイン", class:"btn btn-primary pl-4 pr-4"%>
    </div>
- 
+
   <% end %>
- 
+
  <h5 class="mt-5"><span class="bg-light">会員登録がお済みでない方</span></h5>
    <%= render "public/shared/links" %><h5>から新規登録を行ってください。</h5>
 </div>

--- a/app/views/public/sessions/new.html.erb
+++ b/app/views/public/sessions/new.html.erb
@@ -1,18 +1,18 @@
 <div class="container-lg mx-auto mt-5" style="width: 600px;">
  <h2><span class="bg-light">ログイン<span></h2>
- <% flash[:alert] %>
+  <% flash[:alert] %>
 
  <h4 class="mt-4"><span class="bg-light">会員の方はこちらからログイン</span></h4>
  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
    <div class="field d-flex justify-content-between mt-4" style="width: 400px;">
      <%= f.label :"メールアドレス" %>
      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-    </div>
+    </div> 
    <div class="field d-flex justify-content-between mt-4" style="width: 400px;">
     <%= f.label :"パスワード" %>
     <%= f.password_field :password, autofocus: true, autocomplete: "current-password" %>
    </div>
-
+  
    <% if devise_mapping.rememberable? %>
    <div class="field mt-4">
     <%= f.check_box :remember_me %>
@@ -22,9 +22,9 @@
    <div class="actions d-flex justify-content-center mt-4">
     <%= f.submit "ログイン", class:"btn btn-primary pl-4 pr-4"%>
    </div>
-
+ 
   <% end %>
-
+ 
  <h5 class="mt-5"><span class="bg-light">会員登録がお済みでない方</span></h5>
    <%= render "public/shared/links" %><h5>から新規登録を行ってください。</h5>
 </div>


### PR DESCRIPTION
・レイアウト調整
・管理者側の会員一覧、商品一覧を昇順に変更
・管理者のログアウト後、管理者ログイン画面に遷移するように設定
・退会済み会員のログインの際のフラッシュメッセージ追加
・販売停止中の商品が表示されている問題の修正
・注文履歴詳細から購入者のリンクをクリックすると、注文番号のidが入ってしまい、意図しない画面に遷移する問題の修正

